### PR TITLE
[fix] Declare AVAIL_RECOVERY as a variant

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -139,7 +139,7 @@ listvariants:
 ifeq ($(TARGET_NAME),TARGET_NANOS)
 	@echo VARIANTS COIN AVAIL AVAIL_XL
 else
-	@echo VARIANTS COIN AVAIL
+	@echo VARIANTS COIN AVAIL AVAIL_RECOVERY
 endif
 
 .PHONY: version


### PR DESCRIPTION
@abenso following you latest PR, `AVAIL_RECOVERY` needs to be declared as a variant, else we will not be able to deploy it.
Is this patch ok for you?